### PR TITLE
クラッシュする不具合を修正

### DIFF
--- a/Components/Physicus/PhysicusWorld/PhysicusWorld.cpp
+++ b/Components/Physicus/PhysicusWorld/PhysicusWorld.cpp
@@ -95,6 +95,7 @@ void PhysicusWorld::makePreviewData() {
 	makeRectangleStroke(b2Vec2(0, 200), b2Vec2(300, 230));
 
 	int image = ComponentAssets::shared()->getImages().icons.at(2);
+	auto log = objects_->getImages();
 	objects_->setImages(&image, 1);
 	const int kDistance = 150;
 	for(int i = 0; i  < 5; i++) {
@@ -110,6 +111,7 @@ void PhysicusWorld::makePreviewData() {
 	setting.effect_setting.fill_color = Color::kDeepOrange;
 	setting.effect_setting.effect = true;
 	makeParticleSingle(b2Vec2(200, 200), setting);
+	objects_->setImages(log);
 }
 
 // 縁取りした矩形の即時生成

--- a/MainContent.cpp
+++ b/MainContent.cpp
@@ -125,11 +125,10 @@ void MainContent::run() {
 	// タッチ計算
 	touchMgr_->calc();
 	// パーティクルのタイプをシングルに
-	world_->setParticleType(Physicus::ParticleType::kSingle);
-	// オブジェクトのタイプを手描き線に先行
-	//world_->setObjectType(Physicus::ObjectType::kHandWritten);
+	//world_->setParticleType(Physicus::ParticleType::kSingle);
 	// タッチを物理演算に適用
-	world_->touchParticleCreate(touchMgr_->get());
+	//world_->touchParticleCreate(touchMgr_->get());
+	world_->touchObjectCreate(touchMgr_->get());
 
 	// 時間を進める
 	world_->timeCalc();


### PR DESCRIPTION
原因は画像ハンドルの範囲外参照